### PR TITLE
Fix GitHub Pages build issues and linting errors

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -33,8 +33,7 @@ jobs:
         with:
           ruby-version: '2.7'
           bundler-cache: true
-      - name: Install dependencies
-        run: bundle install
+      # No need for explicit bundle install since bundler-cache: true handles it
       - name: Build with Jekyll
         run: bundle exec jekyll build
       - name: Run HTML Proofer
@@ -50,11 +49,15 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Pages
         uses: actions/configure-pages@v5
-      - name: Build with Jekyll
-        uses: actions/jekyll-build-pages@v1
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
         with:
-          source: ./
-          destination: ./_site
+          ruby-version: '2.7'
+          bundler-cache: true
+      - name: Build with Jekyll
+        run: bundle exec jekyll build
+        env:
+          JEKYLL_ENV: production
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,16 @@
 source "https://rubygems.org"
 
-gem "jekyll", "~> 3.9.3" # Jekyll 3.x series is compatible with Ruby 2.6
-gem "webrick" # Required for Jekyll on Ruby 3.x
+# Jekyll with specific version for compatibility
+gem "jekyll", "~> 3.9.3"
+gem "kramdown-parser-gfm" # Required for Jekyll 3.x with newer kramdown
+
+# Required for Ruby 3.x compatibility
+gem "webrick" 
+
+# Additional dependencies
 gem "logger"
 gem "csv"
 gem "base64"
-gem "kramdown-parser-gfm" # Required for Jekyll 3.x with newer kramdown
-gem "html-proofer" # For linting HTML in CI
+
+# For linting HTML in CI
+gem "html-proofer"


### PR DESCRIPTION
1. Renamed Gemfile and Gemfile.lock to use correct lowercase naming
2. Updated workflow to use custom Jekyll build instead of github-pages
3. Added alt text to portfolio images for accessibility
4. Removed redundant bundle install step in workflow