### PR TITLE
Potential fix for code scanning alert no. 13: Unsafe jQuery plugin

### DIFF
--- a/js/bootstrap.js
+++ b/js/bootstrap.js
@@ -1319,6 +1319,11 @@ if (typeof jQuery === 'undefined') {
       
       // Handle viewport object with selector
       if (viewport.selector) {
+        // Validate and sanitize the selector
+        if (typeof viewport.selector !== 'string' || /[<>]/.test(viewport.selector)) {
+          console.warn('Invalid viewport.selector provided. Defaulting to "body".');
+          viewport.selector = 'body';
+        }
         if (viewport.selector === 'body') {
           viewportEl = document.body
         } else if (viewport.selector.charAt(0) === '#') {


### PR DESCRIPTION
Potential fix for [https://github.com/nord3l/RafBristolPT/security/code-scanning/13](https://github.com/nord3l/RafBristolPT/security/code-scanning/13)

To fix the issue, we need to validate and sanitize the `viewport.selector` option before using it in DOM queries. Specifically:
1. Ensure that `viewport.selector` is a valid CSS selector or a safe string.
2. Reject or sanitize any input that could lead to unintended behavior, such as strings starting with `<` or containing potentially dangerous characters.

The best approach is to add a validation step in the `Tooltip.prototype.init` method before using `viewport.selector`. If the selector is invalid or unsafe, we can either throw an error or default to a safe value (e.g., `'body'`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
