### PR TITLE
Potential fix for code scanning alert no. 14: DOM text reinterpreted as HTML

### DIFF
--- a/js/bootstrap.js
+++ b/js/bootstrap.js
@@ -879,7 +879,7 @@ if (typeof jQuery === 'undefined') {
     if (selector && selector.charAt(0) === '#') {
       $parent = $(document.getElementById(selector.substr(1)))
     } else {
-      $parent = selector ? $(selector) : $()
+      $parent = $() // Return an empty jQuery object for invalid or unsafe selectors
     }
 
     return $parent && $parent.length ? $parent : $this.parent()


### PR DESCRIPTION
Potential fix for [https://github.com/nord3l/RafBristolPT/security/code-scanning/14](https://github.com/nord3l/RafBristolPT/security/code-scanning/14)

To fix the issue, we need to ensure that untrusted input from the `data-target` attribute is not interpreted as HTML or a jQuery selector. Instead of directly passing `selector` to `$()`, we should validate and sanitize it. If the `selector` starts with a `#`, we can safely use `document.getElementById`. Otherwise, we should avoid using it as a jQuery selector and return an empty jQuery object to prevent potential XSS.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
