### PR TITLE
Potential fix for code scanning alert no. 13: Unsafe jQuery plugin

### DIFF
--- a/js/bootstrap.js
+++ b/js/bootstrap.js
@@ -1320,7 +1320,7 @@ if (typeof jQuery === 'undefined') {
       // Handle viewport object with selector
       if (viewport.selector) {
         // Validate and sanitize the selector
-        if (typeof viewport.selector !== 'string' || /[<>]/.test(viewport.selector)) {
+        if (typeof viewport.selector !== 'string' || !/^[#.]?[\w-]+$/.test(viewport.selector)) {
           console.warn('Invalid viewport.selector provided. Defaulting to "body".');
           viewport.selector = 'body';
         }
@@ -1328,8 +1328,11 @@ if (typeof jQuery === 'undefined') {
           viewportEl = document.body
         } else if (viewport.selector.charAt(0) === '#') {
           viewportEl = document.getElementById(viewport.selector.substr(1))
-        } else {
+        } else if (viewport.selector.charAt(0) === '.') {
           viewportEl = document.querySelector(viewport.selector)
+        } else {
+          console.warn('Unsupported selector type. Defaulting to "body".');
+          viewportEl = document.body;
         }
         this.$viewport = viewportEl ? $(viewportEl) : $(document.body)
       } else {


### PR DESCRIPTION
Potential fix for [https://github.com/nord3l/RafBristolPT/security/code-scanning/13](https://github.com/nord3l/RafBristolPT/security/code-scanning/13)

To fix the issue, we need to enhance the sanitization of the `viewport.selector` option to ensure it cannot be used to inject malicious content. This can be achieved by:
1. Strictly validating the `viewport.selector` to ensure it is a valid CSS selector and does not contain any potentially harmful characters or patterns.
2. Using a whitelist approach to allow only safe selectors, such as IDs, classes, or specific tags.
3. Documenting the `viewport.selector` option to inform users about its intended use and the sanitization applied.

The changes will be made in the `Tooltip.prototype.init` method, specifically in the block where `viewport.selector` is processed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
