### PR TITLE
Potential fix for code scanning alert no. 13: Unsafe jQuery plugin

### DIFF
--- a/js/bootstrap.js
+++ b/js/bootstrap.js
@@ -1337,7 +1337,18 @@ if (typeof jQuery === 'undefined') {
         this.$viewport = viewportEl ? $(viewportEl) : $(document.body)
       } else {
         // Handle direct element reference
-        this.$viewport = $(viewport)
+        if (typeof viewport === 'string') {
+          try {
+            viewportEl = document.querySelector(viewport);
+          } catch (e) {
+            viewportEl = null;
+          }
+          this.$viewport = viewportEl ? $(viewportEl) : $(document.body);
+        } else if (viewport instanceof Element || (viewport && viewport.jquery)) {
+          this.$viewport = $(viewport);
+        } else {
+          this.$viewport = $(document.body);
+        }
       }
     } else {
       this.$viewport = null


### PR DESCRIPTION
Potential fix for [https://github.com/nord3l/RafBristolPT/security/code-scanning/13](https://github.com/nord3l/RafBristolPT/security/code-scanning/13)

To fix the issue, we need to validate and sanitize the `viewport` option before using it to create a jQuery object. Specifically:
1. If `viewport` is a string, ensure it is a valid CSS selector by attempting to use it with `document.querySelector`. If it fails, default to a safe value (e.g., `document.body`).
2. If `viewport` is not a string, ensure it is a valid DOM element or jQuery object.
3. Update the code in the `Tooltip.prototype.init` method where `viewport` is processed (lines 1316–1344).

This fix ensures that only safe and valid values are used for the `viewport` option, mitigating the risk of XSS.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
